### PR TITLE
Made Mongo DB start with PID 1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,5 +4,5 @@ ADD mongod.conf /etc/
 
 EXPOSE 27017 28017
 
-CMD mongod -f /etc/mongod.conf
+CMD exec mongod -f /etc/mongod.conf
 


### PR DESCRIPTION
Made Mongo DB start with PID 1 to avoid the problem of having an orphan container