### PR TITLE
Explicitly used 3.0.2 version of Mongo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mongo
+FROM mongo:3.0.2
 
 ADD mongod.conf /etc/
 


### PR DESCRIPTION
Because of some errors, explicitly used 3.0.2 version of Mongo instead of latest, and we will see the future mongo upgrade options