### PR TITLE
Integrate configurator

### DIFF
--- a/helm/mongodb/templates/mongo-configurator-job.yaml
+++ b/helm/mongodb/templates/mongo-configurator-job.yaml
@@ -1,0 +1,22 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: mongo-configurator
+  labels:
+    app: mongo-configurator
+    visualize: "true"
+  annotations:
+    "helm.sh/hook": post-install
+spec:
+  template:
+    spec:
+      restartPolicy: "OnFailure"
+      containers:
+      - name: mongo-configurator
+        image: coco/coco-mongodb-configurator:v0.1.0
+        env:
+        - name: ARGS
+        valueFrom:
+          configMapKeyRef:
+            name: global-config
+            key: mongo.addresses.with.admin.port

--- a/helm/mongodb/templates/mongo-configurator-job.yaml
+++ b/helm/mongodb/templates/mongo-configurator-job.yaml
@@ -16,7 +16,7 @@ spec:
         image: coco/coco-mongodb-configurator:v0.1.0
         env:
         - name: ARGS
-        valueFrom:
-          configMapKeyRef:
-            name: global-config
-            key: mongo.addresses.with.admin.port
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: mongo.addresses.with.admin.port


### PR DESCRIPTION
- deleted `mongo-configurator` from `k8s-aws-delivery-poc`
  - https://github.com/Financial-Times/k8s-aws-delivery-poc/commit/7787227089257ff54999deaaaa58ade867e54b1f
- integrated `mongo-configurator` with the mongo chart, it will be called whenever mongo is **installed** (this means on provisioning), NOT on updates