### PR TITLE
Increase liveness probe initial delay

### DIFF
--- a/helm/mongodb/templates/deployment.yaml
+++ b/helm/mongodb/templates/deployment.yaml
@@ -57,7 +57,7 @@ spec:
         livenessProbe:
           tcpSocket:
             port: 27017
-          initialDelaySeconds: 15
+          initialDelaySeconds: 60
         volumeMounts:
         - name: mongo-persistent-{{ . }}
           mountPath: /data/db


### PR DESCRIPTION
- in some cases, like when recovering journals on startup, we need a longer delay before checking for liveness
- this doesn't cover all cases, and can be adjusted on a case-by-case basis by editing the deployment using `kubectl edit deployment mongodb-x`