### PR TITLE
Automatically recreating RUNBOOK.md without relationships [Skip CI]

### DIFF
--- a/runbooks/mongodb-runbook.md
+++ b/runbooks/mongodb-runbook.md
@@ -1,6 +1,14 @@
+<!--
+    Written in the format prescribed by https://github.com/Financial-Times/runbook.md.
+    Any future edits should abide by this format.
+-->
 # UPP - Mongo DB
 
 Document data store that all the UPP content is stored both before transformation and afterwards
+
+## Code
+
+upp-mongodb
 
 ## Primary URL
 
@@ -13,27 +21,6 @@ Platinum
 ## Lifecycle Stage
 
 Production
-
-## Delivered By
-
-content
-
-## Supported By
-
-content
-
-## Known About By
-
-- dimitar.terziev
-- hristo.georgiev
-- elina.kaneva
-- elitsa.pavlova
-- kalin.arsov
-- miroslav.gatsanoga
-- mihail.mihaylov
-- boyko.boykov
-- ivan.nikolov
-- tsvetan.dimitrov
 
 ## Host Platform
 
@@ -51,6 +38,20 @@ No
 
 No
 
+<!-- Placeholder - remove HTML comment markers to activate
+## Can Download Personal Data
+Choose Yes or No
+
+...or delete this placeholder if not applicable to this system
+-->
+
+<!-- Placeholder - remove HTML comment markers to activate
+## Can Contact Individuals
+Choose Yes or No
+
+...or delete this placeholder if not applicable to this system
+-->
+
 ## Failover Architecture Type
 
 ActivePassive
@@ -67,8 +68,8 @@ PartiallyAutomated
 
 The service is deployed both in Publish and Delivery clusters with different configs. So you can follow these guides:
 
-- For publish: https://github.com/Financial-Times/upp-docs/tree/master/failover-guides/publishing-cluster
-- For delivery: https://github.com/Financial-Times/upp-docs/tree/master/failover-guides/delivery-cluster
+*   For publish: <https://github.com/Financial-Times/upp-docs/tree/master/failover-guides/publishing-cluster>
+*   For delivery: <https://github.com/Financial-Times/upp-docs/tree/master/failover-guides/delivery-cluster>
 
 ## Data Recovery Process Type
 
@@ -90,7 +91,15 @@ Manual
 
 Manual failover is needed when a new version of the service is deployed to production (both publishing and delivery cluster).
 Otherwise, an automated failover is going to take place when releasing to publishing cluster.
-For more details about failover process please see: https://github.com/Financial-Times/upp-docs/tree/master/failover-guides/
+For more details about failover process please see: <https://github.com/Financial-Times/upp-docs/tree/master/failover-guides/>
+
+<!-- Placeholder - remove HTML comment markers to activate
+## Heroku Pipeline Name
+Enter descriptive text satisfying the following:
+This is the name of the Heroku pipeline for this system. If you don't have a pipeline, this is the name of the app in Heroku. A pipeline is a group of Heroku apps that share the same codebase where each app in a pipeline represents the different stages in a continuous delivery workflow, i.e. staging, production.
+
+...or delete this placeholder if not applicable to this system
+-->
 
 ## Key Management Process Type
 
@@ -102,15 +111,15 @@ None
 
 ## Monitoring
 
-- https://upp-prod-publish-us.upp.ft.com/__health
-- https://upp-prod-publish-eu.upp.ft.com/__health
-- https://upp-prod-delivery-us.upp.ft.com/__health
-- https://upp-prod-delivery-eu.upp.ft.com/__health
+*   <https://upp-prod-publish-us.upp.ft.com/__health>
+*   <https://upp-prod-publish-eu.upp.ft.com/__health>
+*   <https://upp-prod-delivery-us.upp.ft.com/__health>
+*   <https://upp-prod-delivery-eu.upp.ft.com/__health>
 
 ## First Line Troubleshooting
 
-https://github.com/Financial-Times/upp-docs/tree/master/guides/ops/first-line-troubleshooting
+<https://github.com/Financial-Times/upp-docs/tree/master/guides/ops/first-line-troubleshooting>
 
 ## Second Line Troubleshooting
 
-Please refer to the https://github.com/Financial-Times/coco-mongodb/blob/master/README.md for more troubleshooting information.
+Please refer to the <https://github.com/Financial-Times/coco-mongodb/blob/master/README.md> for more troubleshooting information.


### PR DESCRIPTION

## What
 - The [RUNBOOK.md](https://github.com/Financial-Times/coco-mongodb/blob/runbook-no-relationships-2021-03-19/runbooks/mongodb-runbook.md) file has been automatically regenerated from the Biz Ops data for the **upp-mongodb** system.
 - All the relationships/dependencies have been excluded from RUNBOOK.md but are still in the **upp-mongodb** system in [Biz Ops](https://biz-ops.in.ft.com/System/upp-mongodb).
 - Please continue to manage those relationships/dependencies manually or via the Biz Ops API.

## Why
 - Support for relationships/dependencies within RUNBOOK.md is being removed to avoid the side effects [identified in this proposal](https://docs.google.com/document/d/1njFceyb49TeaIR53Y9r62CenTzdey1fyeJkUvxd9SQQ)
 - This is a prerequisite to the improved ownership/support model [defined in this proposal](https://docs.google.com/document/d/1vTRe7S5dUqIMAoWyqD2pMEkg_5998NCEeFwsxT_k9pw).

## Next Steps
 - Please check and merge this PR.
 - You should only see the removal of the **Delivered By**, **Supported By**, **Technical Owner**, **Known About By**, **Stakeholders**, **Dependencies** and **Healthcheck** sections. Please contact [#reliability-eng](https://financialtimes.slack.com/archives/C07B3043U) if there are other differences as your current runbook.md file may be inconsistent with Biz Ops.
 - [Reliability Engineering](https://financialtimes.slack.com/archives/C07B3043U) are unlocking all the relationships/dependencies to re-enable manual/API updates.
 - [Reliability Engineering](https://financialtimes.slack.com/archives/C07B3043U) are adjusting the rules to allow these simpler RUNBOOK.md files to pass validation.
